### PR TITLE
Add 共通コントローラーエラーを定義

### DIFF
--- a/go/interfaces/controllers/common_error.go
+++ b/go/interfaces/controllers/common_error.go
@@ -1,0 +1,11 @@
+package controllers
+
+import (
+	"github.com/labstack/echo"
+	"net/http"
+)
+
+// SQLError return 500 and message
+func SQLError(c echo.Context, message interface{}) {
+	c.JSON(http.StatusInternalServerError, message)
+}

--- a/go/interfaces/controllers/user.go
+++ b/go/interfaces/controllers/user.go
@@ -12,7 +12,7 @@ func Index() echo.HandlerFunc {
 	return func(c echo.Context) error {
 		rows := model.AllUser()
 		if rows.Error != nil {
-			c.JSON(http.StatusInternalServerError, "SQL Error")
+			SQLError(c, rows.Error)
 		}
 		return c.JSON(http.StatusOK, rows)
 	}


### PR DESCRIPTION
コントローラー内で、共通に使えるエラーレスポンス用の処理を定義しました。
- （例）gormでsql接続した際にエラーが発生　→ 500 error でエラーメッセージを返す