### PR TITLE
ユーザー作成時のバリデーション作成とRESTなユーザー作成

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -4,11 +4,14 @@ go 1.14
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/jinzhu/gorm v1.9.12
 	github.com/joho/godotenv v1.3.0
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.3.0 // indirect
+	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/stretchr/testify v1.5.1
 	github.com/valyala/fasttemplate v1.1.0 // indirect
 	golang.org/x/crypto v0.0.0-20200406173513-056763e48d71
+	gopkg.in/go-playground/validator.v9 v9.31.0
 )

--- a/go/go.sum
+++ b/go/go.sum
@@ -5,6 +5,10 @@ github.com/dgrijalva/jwt-go v1.0.2 h1:KPldsxuKGsS2FPWsNeg9ZO18aCrGKujPoWXn2yo+KQ
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
+github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
+github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
+github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=
+github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -20,6 +24,8 @@ github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8
 github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
 github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
+github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
+github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lib/pq v1.1.1 h1:sJZmqHoEaY7f+NPP8pgLB/WxulyR3fewgCM2qaSlBb4=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
@@ -54,7 +60,12 @@ golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
+golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/go-playground/validator.v9 v9.31.0 h1:bmXmP2RSNtFES+bn4uYuHT7iJFJv7Vj+an+ZQdDaD1M=
+gopkg.in/go-playground/validator.v9 v9.31.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go/infrastructure/router.go
+++ b/go/infrastructure/router.go
@@ -21,6 +21,7 @@ func Init() {
 	api := e.Group("/api")
 	api.Use(middleware.JWTWithConfig(controllers.Config))
 	api.GET("/users", controllers.Index)
+	api.POST("/users", controllers.Signup)
 	api.GET("/me", controllers.UserIDFromToken)
 	e.Start(":3000")
 }

--- a/go/interfaces/controllers/user.go
+++ b/go/interfaces/controllers/user.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"go_auth/domain"
 	"go_auth/interfaces/model"
+	"go_auth/utils"
 	"net/http"
 	"time"
 
@@ -47,8 +48,9 @@ func Signup(c echo.Context) error {
 	if err := c.Bind(user); err != nil {
 		return err
 	}
+	validateUser := utils.ValidateUser{Email: user.UID, Password: user.Password}
 	// validation
-	if user.UID == "" || user.Password == "" {
+	if !utils.UserValidation(validateUser) {
 		return &echo.HTTPError{
 			Code:    http.StatusBadRequest,
 			Message: "invalid uid or password",

--- a/go/interfaces/controllers/user_test.go
+++ b/go/interfaces/controllers/user_test.go
@@ -99,13 +99,6 @@ func TestMeOK(t *testing.T) {
 	}
 }
 
-// api/users/createのテスト
-func TestCreateUser(t *testing.T) {
-	// okパラメーター
-	okJSON := `{"uid":"test@example.com","password": "password","name":"test"}`
-	fmt.Println(okJSON)
-}
-
 // テスト用レコード物理削除関数
 func phisDelete(db *gorm.DB, user *domain.User) {
 	if user.ID == 0 {

--- a/go/utils/validation.go
+++ b/go/utils/validation.go
@@ -1,14 +1,20 @@
 package utils
 
 import (
-	"unicode/utf8"
+	"gopkg.in/go-playground/validator.v9"
 )
 
-// PasswordValidtion パスワードのバリデーション判定を行う
-func PasswordValidtion(password string) (result bool) {
-	// 現段階では文字数制限のみ
-	length := utf8.RuneCountInString(password)
-	if length < 8 {
+// ValidateUser struct of validation user
+type ValidateUser struct {
+	Email    string `validate:"required,email"` //必須パラメータ、かつ、emailフォーマット
+	Password string `validate:"required,min=8,max=255"`
+}
+
+// UserValidation パスワード及びemailアドレスのバリデーション
+func UserValidation(user ValidateUser) (result bool) {
+	validate := validator.New()
+	err := validate.Struct(user)
+	if err != nil {
 		result = false
 	} else {
 		result = true

--- a/go/utils/validation.go
+++ b/go/utils/validation.go
@@ -1,0 +1,17 @@
+package utils
+
+import (
+	"unicode/utf8"
+)
+
+// PasswordValidtion パスワードのバリデーション判定を行う
+func PasswordValidtion(password string) (result bool) {
+	// 現段階では文字数制限のみ
+	length := utf8.RuneCountInString(password)
+	if length < 8 {
+		result = false
+	} else {
+		result = true
+	}
+	return result
+}

--- a/go/utils/validation_test.go
+++ b/go/utils/validation_test.go
@@ -1,0 +1,17 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// PasswordValidtionのテスト
+func TestPasswordValidtion(t *testing.T) {
+	okStr := "Dfaeytgd"
+	ngStr := "1234567"
+	res1 := PasswordValidtion(okStr)
+	res2 := PasswordValidtion(ngStr)
+	assert.Equal(t, res1, true)
+	assert.Equal(t, res2, false)
+}

--- a/go/utils/validation_test.go
+++ b/go/utils/validation_test.go
@@ -6,12 +6,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// PasswordValidtionのテスト
-func TestPasswordValidtion(t *testing.T) {
-	okStr := "Dfaeytgd"
-	ngStr := "1234567"
-	res1 := PasswordValidtion(okStr)
-	res2 := PasswordValidtion(ngStr)
+// UserValidationのテスト
+func TestUserValidation(t *testing.T) {
+	okuser := ValidateUser{Email: "test@example.com", Password: "drdfaLdar"}
+	nguser1 := ValidateUser{Email: "@tesple.com", Password: "drdfaLdar"}
+	nguser2 := ValidateUser{Email: "test@example.com", Password: "ldafag"}
+	res1 := UserValidation(okuser)
+	res2 := UserValidation(nguser1)
+	res3 := UserValidation(nguser2)
 	assert.Equal(t, res1, true)
 	assert.Equal(t, res2, false)
+	assert.Equal(t, res3, false)
 }


### PR DESCRIPTION
# 概要
- ユーザーサインアップ時にバリデーションを行う処理を追加
- バリデーションを行う関数のテストを追加
- 認証済みユーザーがアクセスできる/api配下にユーザー作成用処理をできるように追加